### PR TITLE
v20: Limit number of decimal places of values sent to charge points

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 0.1.5 (unreleased)
 ------------------
 
+- Fix: Limit decimal values to 6 places when sending a value to a charging station
 - New: Add usage examples to README.rst.
 - Technical: Make OCPPMessage.messageTypeId a class attribute to make instantiation easier.
 - Fix: Serialization of List[non-ComplexType] fields.

--- a/ocpp_codec/v20/types.py
+++ b/ocpp_codec/v20/types.py
@@ -370,7 +370,7 @@ class ConnectorStatusEnumType(types.SimpleType):
 
 @dataclass
 class Decimal(types.SimpleType):
-    value: float = field(metadata={'validator': validators.decimal_precision_1})
+    value: float = field(metadata={'validator': validators.OutgoingMessageDecimalEncoder()})
 
 
 @dataclass

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -56,8 +56,8 @@ def test_max_length_validators():
 
 def test_decimal_precision_validators():
     with pytest.raises(errors.PropertyConstraintViolationError):
-        validators.decimal(1, 1.23)
-    assert validators.decimal(1, 1.2) == 1.2
+        validators.decimal_validator(1, 1.23)
+    assert validators.decimal_validator(1, 1.2) == 1.2
 
     # Make sure the prepared validators were correctly defined
     with pytest.raises(errors.PropertyConstraintViolationError):
@@ -136,6 +136,23 @@ def test_enum_encoder():
         encoder.to_json('well thats not an enum')
     assert encoder.to_json(TestEnum.A) == 1
     assert encoder.to_json(TestEnum.B) == 'b'
+
+
+def test_outgoing_message_decimal_encoder():
+    encoder = validators.OutgoingMessageDecimalEncoder()
+
+    assert encoder.from_json(1.123456789) == 1.123456789
+
+    with pytest.raises(errors.TypeConstraintViolationError):
+        encoder.to_json('well thats not a float')
+    with pytest.raises(errors.TypeConstraintViolationError):
+        # Too big
+        assert encoder.to_json('112345599999999994030193027055616.1234567890')
+
+    assert encoder.to_json('1.12') == 1.12
+    assert encoder.to_json('1.123456789') == 1.123456
+    assert encoder.to_json('0.00001') == 1e-05
+    assert encoder.to_json('1e-05') == 1e-05
 
 
 def test_compound_validator():


### PR DESCRIPTION
This rectriction can be found in section 2.1.3 "Primitive datatypes" of OCPP 2.0. There doesn't seem to be an equivalent in version 1.6.