### PR TITLE
Some validators rework

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 0.1.5 (unreleased)
 ------------------
 
+- New: Add a dedicated 'encoder' metadata attribute on fields instead of mixing it with validators.
 - Fix: Limit decimal values to 6 places when sending a value to a charging station
 - New: Add usage examples to README.rst.
 - Technical: Make OCPPMessage.messageTypeId a class attribute to make instantiation easier.

--- a/ocpp_codec/encoders.py
+++ b/ocpp_codec/encoders.py
@@ -11,6 +11,7 @@ responsible for raising a 'TypeConstraintViolationError' error if they cannot pr
 
 Encoders are assigned to a dataclass field through its metadata 'encoder' key. Only a single encoder is accepted.
 """
+import abc
 import datetime
 import decimal
 import typing
@@ -21,13 +22,15 @@ import pytz
 from ocpp_codec import errors
 
 
-class BaseEncoder:
+class BaseEncoder(abc.ABC):
     """Base encoder from type A to B."""
 
+    @abc.abstractmethod
     def from_json(self, json_value: typing.Any) -> typing.Any:
         """Encoding function handling conversion from OCPP-JSON to Python types."""
         raise NotImplementedError
 
+    @abc.abstractmethod
     def to_json(self, value: typing.Any) -> typing.Any:
         """Encoding function handling conversion from Python types to OCPP-JSON."""
         raise NotImplementedError

--- a/ocpp_codec/encoders.py
+++ b/ocpp_codec/encoders.py
@@ -1,0 +1,137 @@
+# Copyright (c) Polyconseil SAS. All rights reserved.
+"""Collection of classes that can be used to encode and decode OCPP data.
+
+Encoders are expected to convert the incoming value to another type (e.g.: from a string to a 'datetime.datetime').
+They should raise an appropriate instance of a 'BaseOCPPError' if the input value does not meet the appropriate
+criteria.
+
+Encoders shouldn't run any type checking when parsing ('from_json'), but should when serializing ('to_json'). This is
+because there might be several Python types that can be coerced into the correct OCPP-JSON type required. Encoders are
+responsible for raising a 'TypeConstraintViolationError' error if they cannot process the input.
+
+Encoders are assigned to a dataclass field through its metadata 'encoder' key. Only a single encoder is accepted.
+"""
+import datetime
+import decimal
+import typing
+
+import dateutil.parser
+import pytz
+
+from ocpp_codec import errors
+
+
+class BaseEncoder:
+    """Base encoder from type A to B."""
+
+    def from_json(self, json_value: typing.Any) -> typing.Any:
+        """Encoding function handling conversion from OCPP-JSON to Python types."""
+        raise NotImplementedError
+
+    def to_json(self, value: typing.Any) -> typing.Any:
+        """Encoding function handling conversion from Python types to OCPP-JSON."""
+        raise NotImplementedError
+
+
+class DateTimeEncoder(BaseEncoder):
+    """Encoder for ISO 8601 UTC datetime values.
+
+    This encoder parses strings to 'datetime.datetime' elements, making sure the timezone information is provided and
+    is UTC. It expects any kind of ISO 8601 compatible strings, of any precision.
+
+    This encoder serializes 'datetime.datetime' elements in ISO 8601 compatible strings, with the most precision
+    available.
+    """
+
+    def from_json(self, json_value: str) -> datetime.datetime:
+        try:
+            dt = dateutil.parser.isoparse(json_value)
+        except (ValueError, OverflowError) as exc:
+            raise errors.PropertyConstraintViolationError(
+                f"Date input isn't formatted appropriately",
+                value=json_value,
+            ) from exc
+        else:
+            # Assume naive datetime are UTC, so that we don't reject charge points who expect to speak UTC by default
+            if not dt.tzinfo:
+                dt = dt.replace(tzinfo=pytz.UTC)
+            if dt.tzinfo.tzname(dt) != 'UTC':  # type: ignore # mypy doesn't catch that dt.replace call sets tzinfo
+                raise errors.PropertyConstraintViolationError(
+                    f"Date input must use the UTC timezone, not '{dt.tzinfo}'",
+                    value=dt,
+                )
+            return dt
+
+    def to_json(self, value: datetime.datetime) -> str:
+        if not isinstance(value, datetime.datetime):
+            raise errors.TypeConstraintViolationError(
+                f"Input '{value}' is not a datetime.datetime instance",
+                value=value,
+            )
+
+        if not value.tzinfo or value.tzinfo.tzname(value) != 'UTC':
+            raise errors.PropertyConstraintViolationError(
+                f"Date input must use the UTC timezone, not '{value.tzinfo}'",
+                value=value,
+            )
+
+        return value.isoformat()
+
+
+class EnumEncoder(BaseEncoder):
+    """Encoder for a kind of 'Enum' class.
+
+    This encoder parses strings to 'Enum' instances, based on the provided 'enum_class'.
+
+    This encoder serializes 'Enum' instances to strings.
+    """
+
+    def __init__(self, enum_class):
+        self.enum_class = enum_class
+
+    def from_json(self, json_value):
+        try:
+            enum_instance = self.enum_class(json_value)
+        except ValueError as exc:
+            raise errors.PropertyConstraintViolationError(
+                f"Input '{json_value}' is not a valid entry of enum {self.enum_class.__name__}",
+                value=json_value, enum_class=self.enum_class,
+            ) from exc
+        else:
+            return enum_instance
+
+    def to_json(self, value):
+        if not isinstance(value, self.enum_class):
+            raise errors.TypeConstraintViolationError(
+                f"Input '{value}' is not an instance of '{self.enum_class.__name__}",
+                value=value, enum_class=self.enum_class.__name__,
+            )
+        return value.value
+
+
+class OutgoingMessageDecimalEncoder(BaseEncoder):
+    """Encoder to limit the precision of decimal values sent to charge points.
+
+    This encoder doesn't restricts the precision of float values received from the charge point, as we *must* keep the
+    full resolution, but limits it to 6 places when sending a value, as required by OCPP 2.0 spec (section 2.1.3).
+    """
+
+    def from_json(self, json_value):
+        return json_value
+
+    def to_json(self, value):
+        try:
+            float_value = float(value)
+        except ValueError:
+            raise errors.TypeConstraintViolationError(f"Input '{value}' cannot be cast to float", value=value)
+
+        six_places = decimal.Decimal('1.000000')
+        try:
+            truncated_value = float(decimal.Decimal(float_value).quantize(six_places, rounding=decimal.ROUND_DOWN))
+        except decimal.DecimalException as exc:
+            raise errors.TypeConstraintViolationError(
+                f"Input '{value}' could not be truncated to six decimal places",
+                value=value,
+            ) from exc
+
+        return truncated_value

--- a/ocpp_codec/serializer.py
+++ b/ocpp_codec/serializer.py
@@ -36,10 +36,7 @@ def _required_fields(dataclass_class) -> typing.List[dataclasses.Field]:
 
 def _clean_data(field: dataclasses.Field, data: typing.Any, *, parsing: bool) -> typing.Any:
     # Fetch the validators to run
-    validator_list = field.metadata.get('validators', [validators.noop])
-    # Defining a single validator is supported, turn it to a list for easier processing
-    if not isinstance(validator_list, list):
-        validator_list = [validator_list]
+    validator_list = field.metadata.get('validators', [])
 
     for validator in validator_list:
         try:

--- a/ocpp_codec/serializer.py
+++ b/ocpp_codec/serializer.py
@@ -35,7 +35,7 @@ def _required_fields(dataclass_class) -> typing.List[dataclasses.Field]:
 
 def _run_validator(field: dataclasses.Field, data: typing.Any, *, parsing: bool) -> typing.Any:
     # Fetch the validator to run
-    validator = field.metadata.get('validator', validators.noop)
+    validator = field.metadata.get('validators', validators.noop)
     if isinstance(validator, validators.BaseEncoder):
         # Pick the right method based on whether we're parsing a message, or serializing a field
         validator = validator.from_json if parsing else validator.to_json

--- a/ocpp_codec/structure.py
+++ b/ocpp_codec/structure.py
@@ -20,20 +20,20 @@ class MessageTypeEnum(enum.Enum):
 @dataclass
 class MessageType(types.SimpleType):
     """Field type coercing an integer to a MessageTypeEnum."""
-    value: int = field(metadata={'validator': validators.EnumEncoder(MessageTypeEnum)})
+    value: int = field(metadata={'validators': validators.EnumEncoder(MessageTypeEnum)})
 
 
 @dataclass
 class ErrorCode(types.SimpleType):
     """Field type coercing a string to a ErrorCodeEnum."""
-    value: str = field(metadata={'validator': validators.EnumEncoder(types.ErrorCodeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(types.ErrorCodeEnum)})
 
 
 @dataclass
 class OCPPMessage:
     """Base class every OCPP message should inherit from."""
     messageTypeId: MessageType = field(init=False)  # Let subclasses define that field
-    uniqueId: str = field(metadata={'validator': validators.max_length_36})
+    uniqueId: str = field(metadata={'validators': validators.max_length_36})
 
 
 @dataclass

--- a/ocpp_codec/structure.py
+++ b/ocpp_codec/structure.py
@@ -34,7 +34,7 @@ class ErrorCode(types.SimpleType):
 class OCPPMessage:
     """Base class every OCPP message should inherit from."""
     messageTypeId: MessageType = field(init=False)  # Let subclasses define that field
-    uniqueId: str = field(metadata={'validators': validators.max_length_36})
+    uniqueId: str = field(metadata={'validators': [validators.max_length_36]})
 
 
 @dataclass

--- a/ocpp_codec/structure.py
+++ b/ocpp_codec/structure.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from dataclasses import field
 import enum
 
+from ocpp_codec import encoders
 from ocpp_codec import types
 from ocpp_codec import validators
 
@@ -20,13 +21,13 @@ class MessageTypeEnum(enum.Enum):
 @dataclass
 class MessageType(types.SimpleType):
     """Field type coercing an integer to a MessageTypeEnum."""
-    value: int = field(metadata={'validators': validators.EnumEncoder(MessageTypeEnum)})
+    value: int = field(metadata={'encoder': encoders.EnumEncoder(MessageTypeEnum)})
 
 
 @dataclass
 class ErrorCode(types.SimpleType):
     """Field type coercing a string to a ErrorCodeEnum."""
-    value: str = field(metadata={'validators': validators.EnumEncoder(types.ErrorCodeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(types.ErrorCodeEnum)})
 
 
 @dataclass

--- a/ocpp_codec/types.py
+++ b/ocpp_codec/types.py
@@ -30,7 +30,7 @@ class SimpleType(OCPPType):
 
         @dataclass
         class CiString20Type(SimpleType):
-            value: str = field(metadata={'validators': validators.max_length_20})
+            value: str = field(metadata={'validators': [validators.max_length_20]})
 
         When used as part of another type, CiString20Type is expected to be a string of length 20.
     """

--- a/ocpp_codec/types.py
+++ b/ocpp_codec/types.py
@@ -30,7 +30,7 @@ class SimpleType(OCPPType):
 
         @dataclass
         class CiString20Type(SimpleType):
-            value: str = field(metadata={'validator': validators.max_length_20})
+            value: str = field(metadata={'validators': validators.max_length_20})
 
         When used as part of another type, CiString20Type is expected to be a string of length 20.
     """

--- a/ocpp_codec/v16/types.py
+++ b/ocpp_codec/v16/types.py
@@ -5,6 +5,7 @@ from dataclasses import field
 import enum
 import typing
 
+from ocpp_codec import encoders
 from ocpp_codec import types
 from ocpp_codec import utils
 from ocpp_codec import validators
@@ -255,47 +256,47 @@ class ValueFormatEnum(utils.AutoNameEnum):
 
 @dataclass
 class AuthorizationStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(AuthorizationStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(AuthorizationStatusEnum)})
 
 
 @dataclass
 class AvailabilityStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(AvailabilityStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(AvailabilityStatusEnum)})
 
 
 @dataclass
 class AvailabilityType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(AvailabilityTypeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(AvailabilityTypeEnum)})
 
 
 @dataclass
 class ConfigurationStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ConfigurationStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ConfigurationStatusEnum)})
 
 
 @dataclass
 class ChargePointErrorCode(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ChargePointErrorCodeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ChargePointErrorCodeEnum)})
 
 
 @dataclass
 class ChargePointStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ChargePointStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ChargePointStatusEnum)})
 
 
 @dataclass
 class ChargingProfileKindType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingProfileKindTypeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ChargingProfileKindTypeEnum)})
 
 
 @dataclass
 class ChargingProfilePurposeType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingProfilePurposeTypeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ChargingProfilePurposeTypeEnum)})
 
 
 @dataclass
 class ChargingRateUnitType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingRateUnitTypeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ChargingRateUnitTypeEnum)})
 
 
 @dataclass
@@ -325,17 +326,17 @@ class CiString500Type(types.SimpleType):
 
 @dataclass
 class DataTransferStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(DataTransferStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(DataTransferStatusEnum)})
 
 
 @dataclass
 class DiagnosticsStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(DiagnosticsStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(DiagnosticsStatusEnum)})
 
 
 @dataclass
 class DateTime(types.SimpleType):
-    value: str = field(metadata={'validators': validators.DateTimeEncoder()})
+    value: str = field(metadata={'encoder': encoders.DateTimeEncoder()})
 
 
 @dataclass
@@ -345,7 +346,7 @@ class Decimal(types.SimpleType):
 
 @dataclass
 class FirmwareStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(FirmwareStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(FirmwareStatusEnum)})
 
 
 @dataclass
@@ -355,12 +356,12 @@ class IdToken(CiString20Type):
 
 @dataclass
 class Location(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(LocationEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(LocationEnum)})
 
 
 @dataclass
 class Measurand(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(MeasurandEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(MeasurandEnum)})
 
 
 @dataclass
@@ -375,62 +376,62 @@ class PositiveIntegerNonNull(types.SimpleType):
 
 @dataclass
 class Phase(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(PhaseEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(PhaseEnum)})
 
 
 @dataclass
 class ReadingContext(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ReadingContextEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ReadingContextEnum)})
 
 
 @dataclass
 class Reason(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ReasonEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ReasonEnum)})
 
 
 @dataclass
 class RecurrencyKindType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(RecurrencyKindTypeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(RecurrencyKindTypeEnum)})
 
 
 @dataclass
 class RegistrationStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(RegistrationStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(RegistrationStatusEnum)})
 
 
 @dataclass
 class RemoteStartStopStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(RemoteStartStopStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(RemoteStartStopStatusEnum)})
 
 
 @dataclass
 class ReservationStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ReservationStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ReservationStatusEnum)})
 
 
 @dataclass
 class UnitOfMeasure(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(UnitOfMeasureEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(UnitOfMeasureEnum)})
 
 
 @dataclass
 class UnlockStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(UnlockStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(UnlockStatusEnum)})
 
 
 @dataclass
 class UpdateStatus(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(UpdateStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(UpdateStatusEnum)})
 
 
 @dataclass
 class UpdateType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(UpdateTypeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(UpdateTypeEnum)})
 
 
 @dataclass
 class ValueFormat(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ValueFormatEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ValueFormatEnum)})
 
 
 # Complex types

--- a/ocpp_codec/v16/types.py
+++ b/ocpp_codec/v16/types.py
@@ -255,97 +255,97 @@ class ValueFormatEnum(utils.AutoNameEnum):
 
 @dataclass
 class AuthorizationStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(AuthorizationStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(AuthorizationStatusEnum)})
 
 
 @dataclass
 class AvailabilityStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(AvailabilityStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(AvailabilityStatusEnum)})
 
 
 @dataclass
 class AvailabilityType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(AvailabilityTypeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(AvailabilityTypeEnum)})
 
 
 @dataclass
 class ConfigurationStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ConfigurationStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ConfigurationStatusEnum)})
 
 
 @dataclass
 class ChargePointErrorCode(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ChargePointErrorCodeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ChargePointErrorCodeEnum)})
 
 
 @dataclass
 class ChargePointStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ChargePointStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ChargePointStatusEnum)})
 
 
 @dataclass
 class ChargingProfileKindType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ChargingProfileKindTypeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingProfileKindTypeEnum)})
 
 
 @dataclass
 class ChargingProfilePurposeType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ChargingProfilePurposeTypeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingProfilePurposeTypeEnum)})
 
 
 @dataclass
 class ChargingRateUnitType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ChargingRateUnitTypeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingRateUnitTypeEnum)})
 
 
 @dataclass
 class CiString20Type(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_20})
+    value: str = field(metadata={'validators': validators.max_length_20})
 
 
 @dataclass
 class CiString25Type(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_25})
+    value: str = field(metadata={'validators': validators.max_length_25})
 
 
 @dataclass
 class CiString50Type(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_50})
+    value: str = field(metadata={'validators': validators.max_length_50})
 
 
 @dataclass
 class CiString255Type(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_255})
+    value: str = field(metadata={'validators': validators.max_length_255})
 
 
 @dataclass
 class CiString500Type(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_500})
+    value: str = field(metadata={'validators': validators.max_length_500})
 
 
 @dataclass
 class DataTransferStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(DataTransferStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(DataTransferStatusEnum)})
 
 
 @dataclass
 class DiagnosticsStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(DiagnosticsStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(DiagnosticsStatusEnum)})
 
 
 @dataclass
 class DateTime(types.SimpleType):
-    value: str = field(metadata={'validator': validators.DateTimeEncoder()})
+    value: str = field(metadata={'validators': validators.DateTimeEncoder()})
 
 
 @dataclass
 class Decimal(types.SimpleType):
-    value: float = field(metadata={'validator': validators.decimal_precision_1})
+    value: float = field(metadata={'validators': validators.decimal_precision_1})
 
 
 @dataclass
 class FirmwareStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(FirmwareStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(FirmwareStatusEnum)})
 
 
 @dataclass
@@ -355,82 +355,82 @@ class IdToken(CiString20Type):
 
 @dataclass
 class Location(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(LocationEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(LocationEnum)})
 
 
 @dataclass
 class Measurand(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(MeasurandEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(MeasurandEnum)})
 
 
 @dataclass
 class PositiveInteger(types.SimpleType):
-    value: int = field(metadata={'validator': validators.is_positive})
+    value: int = field(metadata={'validators': validators.is_positive})
 
 
 @dataclass
 class PositiveIntegerNonNull(types.SimpleType):
-    value: int = field(metadata={'validator': validators.is_strictly_positive})
+    value: int = field(metadata={'validators': validators.is_strictly_positive})
 
 
 @dataclass
 class Phase(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(PhaseEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(PhaseEnum)})
 
 
 @dataclass
 class ReadingContext(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ReadingContextEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ReadingContextEnum)})
 
 
 @dataclass
 class Reason(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ReasonEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ReasonEnum)})
 
 
 @dataclass
 class RecurrencyKindType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(RecurrencyKindTypeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(RecurrencyKindTypeEnum)})
 
 
 @dataclass
 class RegistrationStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(RegistrationStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(RegistrationStatusEnum)})
 
 
 @dataclass
 class RemoteStartStopStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(RemoteStartStopStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(RemoteStartStopStatusEnum)})
 
 
 @dataclass
 class ReservationStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ReservationStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ReservationStatusEnum)})
 
 
 @dataclass
 class UnitOfMeasure(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(UnitOfMeasureEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(UnitOfMeasureEnum)})
 
 
 @dataclass
 class UnlockStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(UnlockStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(UnlockStatusEnum)})
 
 
 @dataclass
 class UpdateStatus(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(UpdateStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(UpdateStatusEnum)})
 
 
 @dataclass
 class UpdateType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(UpdateTypeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(UpdateTypeEnum)})
 
 
 @dataclass
 class ValueFormat(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ValueFormatEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ValueFormatEnum)})
 
 
 # Complex types

--- a/ocpp_codec/v16/types.py
+++ b/ocpp_codec/v16/types.py
@@ -301,27 +301,27 @@ class ChargingRateUnitType(types.SimpleType):
 
 @dataclass
 class CiString20Type(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_20})
+    value: str = field(metadata={'validators': [validators.max_length_20]})
 
 
 @dataclass
 class CiString25Type(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_25})
+    value: str = field(metadata={'validators': [validators.max_length_25]})
 
 
 @dataclass
 class CiString50Type(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_50})
+    value: str = field(metadata={'validators': [validators.max_length_50]})
 
 
 @dataclass
 class CiString255Type(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_255})
+    value: str = field(metadata={'validators': [validators.max_length_255]})
 
 
 @dataclass
 class CiString500Type(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_500})
+    value: str = field(metadata={'validators': [validators.max_length_500]})
 
 
 @dataclass
@@ -341,7 +341,7 @@ class DateTime(types.SimpleType):
 
 @dataclass
 class Decimal(types.SimpleType):
-    value: float = field(metadata={'validators': validators.decimal_precision_1})
+    value: float = field(metadata={'validators': [validators.decimal_precision_1]})
 
 
 @dataclass
@@ -366,7 +366,7 @@ class Measurand(types.SimpleType):
 
 @dataclass
 class PositiveInteger(types.SimpleType):
-    value: int = field(metadata={'validators': validators.is_positive})
+    value: int = field(metadata={'validators': [validators.is_positive]})
 
 
 @dataclass

--- a/ocpp_codec/v16/types.py
+++ b/ocpp_codec/v16/types.py
@@ -370,7 +370,7 @@ class PositiveInteger(types.SimpleType):
 
 @dataclass
 class PositiveIntegerNonNull(types.SimpleType):
-    value: int = field(metadata={'validators': validators.is_strictly_positive})
+    value: int = field(metadata={'validators': [validators.is_positive, validators.is_not_zero]})
 
 
 @dataclass

--- a/ocpp_codec/v20/types.py
+++ b/ocpp_codec/v20/types.py
@@ -255,27 +255,28 @@ class TriggerReasonEnum(utils.AutoNameEnum):
     RemoteStop = enum.auto()
     RemoteStart = enum.auto()
 
+
 # Commonly used primitive types aliases
 #######################################
 
 @dataclass
 class _IdentifierString20(types.SimpleType):
     value: str = field(metadata={
-        'validators': validators.compound_validator(validators.max_length_20, validators.is_identifier),
+        'validators': [validators.max_length_20, validators.is_identifier],
     })
 
 
 @dataclass
 class _IdentifierString36(types.SimpleType):
     value: str = field(metadata={
-        'validators': validators.compound_validator(validators.max_length_36, validators.is_identifier),
+        'validators': [validators.max_length_36, validators.is_identifier],
     })
 
 
 @dataclass
 class _IdentifierString128(types.SimpleType):
     value: str = field(metadata={
-        'validators': validators.compound_validator(validators.max_length_128, validators.is_identifier),
+        'validators': [validators.max_length_128, validators.is_identifier],
     })
 
 

--- a/ocpp_codec/v20/types.py
+++ b/ocpp_codec/v20/types.py
@@ -261,57 +261,57 @@ class TriggerReasonEnum(utils.AutoNameEnum):
 @dataclass
 class _IdentifierString20(types.SimpleType):
     value: str = field(metadata={
-        'validator': validators.compound_validator(validators.max_length_20, validators.is_identifier),
+        'validators': validators.compound_validator(validators.max_length_20, validators.is_identifier),
     })
 
 
 @dataclass
 class _IdentifierString36(types.SimpleType):
     value: str = field(metadata={
-        'validator': validators.compound_validator(validators.max_length_36, validators.is_identifier),
+        'validators': validators.compound_validator(validators.max_length_36, validators.is_identifier),
     })
 
 
 @dataclass
 class _IdentifierString128(types.SimpleType):
     value: str = field(metadata={
-        'validator': validators.compound_validator(validators.max_length_128, validators.is_identifier),
+        'validators': validators.compound_validator(validators.max_length_128, validators.is_identifier),
     })
 
 
 @dataclass
 class _String8(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_8})
+    value: str = field(metadata={'validators': validators.max_length_8})
 
 
 @dataclass
 class _String20(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_20})
+    value: str = field(metadata={'validators': validators.max_length_20})
 
 
 @dataclass
 class _String50(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_50})
+    value: str = field(metadata={'validators': validators.max_length_50})
 
 
 @dataclass
 class _String128(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_128})
+    value: str = field(metadata={'validators': validators.max_length_128})
 
 
 @dataclass
 class _String512(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_512})
+    value: str = field(metadata={'validators': validators.max_length_512})
 
 
 @dataclass
 class _String1000(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_1000})
+    value: str = field(metadata={'validators': validators.max_length_1000})
 
 
 @dataclass
 class _String2500(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_2500})
+    value: str = field(metadata={'validators': validators.max_length_2500})
 
 
 # Field definitions for tricky cases
@@ -327,7 +327,7 @@ class _String2500(types.SimpleType):
 # doesn't work because ListCard4[int] for example isn't considered a dataclass, while ListCard4 is, but extracting the
 # type of the 'value' field yields, quite naturally, ~T. We'd like to be able to extract the concrete type of a
 # ListCard4[int] along with the field validators.
-ListCard4Field = functools.partial(field, metadata={'validator': validators.max_length_4})
+ListCard4Field = functools.partial(field, metadata={'validators': validators.max_length_4})
 
 
 # Simple types
@@ -335,132 +335,132 @@ ListCard4Field = functools.partial(field, metadata={'validator': validators.max_
 
 @dataclass
 class AuthorizationStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(AuthorizationStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(AuthorizationStatusEnum)})
 
 
 @dataclass
 class AttributeEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(AttributeEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(AttributeEnum)})
 
 
 @dataclass
 class BootReasonEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(BootReasonEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(BootReasonEnum)})
 
 
 @dataclass
 class CertificateStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(CertificateStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(CertificateStatusEnum)})
 
 
 @dataclass
 class ChangeAvailabilityStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ChangeAvailabilityStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ChangeAvailabilityStatusEnum)})
 
 
 @dataclass
 class ChargingStateEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ChargingStateEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingStateEnum)})
 
 
 @dataclass
 class ConnectorStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ConnectorStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ConnectorStatusEnum)})
 
 
 @dataclass
 class Decimal(types.SimpleType):
-    value: float = field(metadata={'validator': validators.OutgoingMessageDecimalEncoder()})
+    value: float = field(metadata={'validators': validators.OutgoingMessageDecimalEncoder()})
 
 
 @dataclass
 class DateTime(types.SimpleType):
-    value: str = field(metadata={'validator': validators.DateTimeEncoder()})
+    value: str = field(metadata={'validators': validators.DateTimeEncoder()})
 
 
 @dataclass
 class EncodingMethodEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(EncodingMethodEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(EncodingMethodEnum)})
 
 
 @dataclass
 class GetVariableStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(GetVariableStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(GetVariableStatusEnum)})
 
 
 @dataclass
 class HashAlgorithmEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(HashAlgorithmEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(HashAlgorithmEnum)})
 
 
 @dataclass
 class IdTokenEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(IdTokenEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(IdTokenEnum)})
 
 
 @dataclass
 class LocationEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(LocationEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(LocationEnum)})
 
 
 @dataclass
 class MeasurandEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(MeasurandEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(MeasurandEnum)})
 
 
 @dataclass
 class MessageFormatEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(MessageFormatEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(MessageFormatEnum)})
 
 
 @dataclass
 class OperationalStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(OperationalStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(OperationalStatusEnum)})
 
 
 @dataclass
 class PhaseEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(PhaseEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(PhaseEnum)})
 
 
 @dataclass
 class ReadingContextEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ReadingContextEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ReadingContextEnum)})
 
 
 @dataclass
 class ReasonEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(ReasonEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(ReasonEnum)})
 
 
 @dataclass
 class RegistrationStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(RegistrationStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(RegistrationStatusEnum)})
 
 
 @dataclass
 class SetVariableStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(SetVariableStatusEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(SetVariableStatusEnum)})
 
 
 @dataclass
 class SignatureMethodEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(SignatureMethodEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(SignatureMethodEnum)})
 
 
 @dataclass
 class TransactionEventEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(TransactionEventEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(TransactionEventEnum)})
 
 
 @dataclass
 class TriggerReasonEnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(TriggerReasonEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(TriggerReasonEnum)})
 
 
 @dataclass
 class UnitOfMeasureType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_20})
+    value: str = field(metadata={'validators': validators.max_length_20})
 
 
 # Complex types

--- a/ocpp_codec/v20/types.py
+++ b/ocpp_codec/v20/types.py
@@ -283,37 +283,37 @@ class _IdentifierString128(types.SimpleType):
 
 @dataclass
 class _String8(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_8})
+    value: str = field(metadata={'validators': [validators.max_length_8]})
 
 
 @dataclass
 class _String20(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_20})
+    value: str = field(metadata={'validators': [validators.max_length_20]})
 
 
 @dataclass
 class _String50(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_50})
+    value: str = field(metadata={'validators': [validators.max_length_50]})
 
 
 @dataclass
 class _String128(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_128})
+    value: str = field(metadata={'validators': [validators.max_length_128]})
 
 
 @dataclass
 class _String512(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_512})
+    value: str = field(metadata={'validators': [validators.max_length_512]})
 
 
 @dataclass
 class _String1000(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_1000})
+    value: str = field(metadata={'validators': [validators.max_length_1000]})
 
 
 @dataclass
 class _String2500(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_2500})
+    value: str = field(metadata={'validators': [validators.max_length_2500]})
 
 
 # Field definitions for tricky cases
@@ -329,7 +329,7 @@ class _String2500(types.SimpleType):
 # doesn't work because ListCard4[int] for example isn't considered a dataclass, while ListCard4 is, but extracting the
 # type of the 'value' field yields, quite naturally, ~T. We'd like to be able to extract the concrete type of a
 # ListCard4[int] along with the field validators.
-ListCard4Field = functools.partial(field, metadata={'validators': validators.max_length_4})
+ListCard4Field = functools.partial(field, metadata={'validators': [validators.max_length_4]})
 
 
 # Simple types
@@ -462,7 +462,7 @@ class TriggerReasonEnumType(types.SimpleType):
 
 @dataclass
 class UnitOfMeasureType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_20})
+    value: str = field(metadata={'validators': [validators.max_length_20]})
 
 
 # Complex types

--- a/ocpp_codec/v20/types.py
+++ b/ocpp_codec/v20/types.py
@@ -6,6 +6,7 @@ import enum
 import functools
 import typing
 
+from ocpp_codec import encoders
 from ocpp_codec import types
 from ocpp_codec import utils
 from ocpp_codec import validators
@@ -336,127 +337,127 @@ ListCard4Field = functools.partial(field, metadata={'validators': validators.max
 
 @dataclass
 class AuthorizationStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(AuthorizationStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(AuthorizationStatusEnum)})
 
 
 @dataclass
 class AttributeEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(AttributeEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(AttributeEnum)})
 
 
 @dataclass
 class BootReasonEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(BootReasonEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(BootReasonEnum)})
 
 
 @dataclass
 class CertificateStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(CertificateStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(CertificateStatusEnum)})
 
 
 @dataclass
 class ChangeAvailabilityStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ChangeAvailabilityStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ChangeAvailabilityStatusEnum)})
 
 
 @dataclass
 class ChargingStateEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ChargingStateEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ChargingStateEnum)})
 
 
 @dataclass
 class ConnectorStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ConnectorStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ConnectorStatusEnum)})
 
 
 @dataclass
 class Decimal(types.SimpleType):
-    value: float = field(metadata={'validators': validators.OutgoingMessageDecimalEncoder()})
+    value: float = field(metadata={'encoder': encoders.OutgoingMessageDecimalEncoder()})
 
 
 @dataclass
 class DateTime(types.SimpleType):
-    value: str = field(metadata={'validators': validators.DateTimeEncoder()})
+    value: str = field(metadata={'encoder': encoders.DateTimeEncoder()})
 
 
 @dataclass
 class EncodingMethodEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(EncodingMethodEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(EncodingMethodEnum)})
 
 
 @dataclass
 class GetVariableStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(GetVariableStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(GetVariableStatusEnum)})
 
 
 @dataclass
 class HashAlgorithmEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(HashAlgorithmEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(HashAlgorithmEnum)})
 
 
 @dataclass
 class IdTokenEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(IdTokenEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(IdTokenEnum)})
 
 
 @dataclass
 class LocationEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(LocationEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(LocationEnum)})
 
 
 @dataclass
 class MeasurandEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(MeasurandEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(MeasurandEnum)})
 
 
 @dataclass
 class MessageFormatEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(MessageFormatEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(MessageFormatEnum)})
 
 
 @dataclass
 class OperationalStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(OperationalStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(OperationalStatusEnum)})
 
 
 @dataclass
 class PhaseEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(PhaseEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(PhaseEnum)})
 
 
 @dataclass
 class ReadingContextEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ReadingContextEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ReadingContextEnum)})
 
 
 @dataclass
 class ReasonEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(ReasonEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(ReasonEnum)})
 
 
 @dataclass
 class RegistrationStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(RegistrationStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(RegistrationStatusEnum)})
 
 
 @dataclass
 class SetVariableStatusEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(SetVariableStatusEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(SetVariableStatusEnum)})
 
 
 @dataclass
 class SignatureMethodEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(SignatureMethodEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(SignatureMethodEnum)})
 
 
 @dataclass
 class TransactionEventEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(TransactionEventEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(TransactionEventEnum)})
 
 
 @dataclass
 class TriggerReasonEnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(TriggerReasonEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(TriggerReasonEnum)})
 
 
 @dataclass

--- a/ocpp_codec/validators.py
+++ b/ocpp_codec/validators.py
@@ -14,7 +14,7 @@ Encoders shouldn't run any type checking when parsing ('from_json'), but should 
 because there might be several Python types that can be coerced into the correct OCPP-JSON type required. The validator
 is responsible for raising a 'TypeConstraintViolationError' error if it cannot process the input.
 
-Validators are assigned to a dataclass field through its metadata 'validator' key.
+Validators are assigned to a dataclass field through its metadata 'validators' key.
 """
 import datetime
 import decimal

--- a/ocpp_codec/validators.py
+++ b/ocpp_codec/validators.py
@@ -1,29 +1,20 @@
 # Copyright (c) Polyconseil SAS. All rights reserved.
-"""Collection of functions and classes that can be used to validate OCPP input.
+"""Collection of functions that can be used to validate OCPP input.
 
-There exists two kinds of validators: simple functions and encoders.
+Validators take an input and validate it without altering its typing. They should raise an appropriate instance of a
+'BaseOCPPError' if the input value does not meet the appropriate criteria. Validators are written so that they return
+their input, but there's no use for it for now.
 
-The functions take an input and validate it without altering its typing, whereas encoders are expected to convert the
-incoming value to another type (e.g.: from a string to a 'datetime.datetime'). Both should raise an appropriate instance
-of a 'BaseOCPPError' if the input value does not meet the appropriate criteria. Validators are expected to return the
-value unaltered so that their API matches encoders.
+Validators shouldn't run any type checking, this is taken care of before they're called.
 
-Simple functions validators shouldn't run any type checking, this is taken care of before they're called.
+Validators are responsible for raising a 'TypeConstraintViolationError' error if they cannot process the input.
 
-Encoders shouldn't run any type checking when parsing ('from_json'), but should when serializing ('to_json'). This is
-because there might be several Python types that can be coerced into the correct OCPP-JSON type required. The validator
-is responsible for raising a 'TypeConstraintViolationError' error if it cannot process the input.
-
-Validators are assigned to a dataclass field through its metadata 'validators' key.
+Validators are assigned to a dataclass field through its metadata 'validators' key. A single validator can be provided,
+or several in a list.
 """
-import datetime
-import decimal
 import functools
 import re
 import typing
-
-import dateutil.parser
-import pytz
 
 from ocpp_codec import errors
 
@@ -113,123 +104,3 @@ def is_identifier(value: str) -> str:
             pattern=_IDENTIFIER_REGEXP.pattern,
         )
     return value
-
-
-##########
-# Encoders
-
-
-class BaseEncoder:
-    """Base encoder from type A to B."""
-
-    def from_json(self, json_value: typing.Any) -> typing.Any:
-        """Encoding function handling conversion from OCPP-JSON to Python types."""
-        raise NotImplementedError
-
-    def to_json(self, value: typing.Any) -> typing.Any:
-        """Encoding function handling conversion from Python types to OCPP-JSON."""
-        raise NotImplementedError
-
-
-class DateTimeEncoder(BaseEncoder):
-    """Encoder for ISO 8601 UTC datetime values.
-
-    This encoder parses strings to 'datetime.datetime' elements, making sure the timezone information is provided and
-    is UTC. It expects any kind of ISO 8601 compatible strings, of any precision.
-
-    This encoder serializes 'datetime.datetime' elements in ISO 8601 compatible strings, with the most precision
-    available.
-    """
-
-    def from_json(self, json_value: str) -> datetime.datetime:
-        try:
-            dt = dateutil.parser.isoparse(json_value)
-        except (ValueError, OverflowError) as exc:
-            raise errors.PropertyConstraintViolationError(
-                f"Date input isn't formatted appropriately",
-                value=json_value,
-            ) from exc
-        else:
-            # Assume naive datetime are UTC, so that we don't reject charge points who expect to speak UTC by default
-            if not dt.tzinfo:
-                dt = dt.replace(tzinfo=pytz.UTC)
-            if dt.tzinfo.tzname(dt) != 'UTC':  # type: ignore # mypy doesn't catch that dt.replace call sets tzinfo
-                raise errors.PropertyConstraintViolationError(
-                    f"Date input must use the UTC timezone, not '{dt.tzinfo}'",
-                    value=dt,
-                )
-            return dt
-
-    def to_json(self, value: datetime.datetime) -> str:
-        if not isinstance(value, datetime.datetime):
-            raise errors.TypeConstraintViolationError(
-                f"Input '{value}' is not a datetime.datetime instance",
-                value=value,
-            )
-
-        if not value.tzinfo or value.tzinfo.tzname(value) != 'UTC':
-            raise errors.PropertyConstraintViolationError(
-                f"Date input must use the UTC timezone, not '{value.tzinfo}'",
-                value=value,
-            )
-
-        return value.isoformat()
-
-
-class EnumEncoder(BaseEncoder):
-    """Encoder for a kind of 'Enum' class.
-
-    This encoder parses strings to 'Enum' instances, based on the provided 'enum_class'.
-
-    This encoder serializes 'Enum' instances to strings.
-    """
-
-    def __init__(self, enum_class):
-        self.enum_class = enum_class
-
-    def from_json(self, json_value):
-        try:
-            enum_instance = self.enum_class(json_value)
-        except ValueError as exc:
-            raise errors.PropertyConstraintViolationError(
-                f"Input '{json_value}' is not a valid entry of enum {self.enum_class.__name__}",
-                value=json_value, enum_class=self.enum_class,
-            ) from exc
-        else:
-            return enum_instance
-
-    def to_json(self, value):
-        if not isinstance(value, self.enum_class):
-            raise errors.TypeConstraintViolationError(
-                f"Input '{value}' is not an instance of '{self.enum_class.__name__}",
-                value=value, enum_class=self.enum_class.__name__,
-            )
-        return value.value
-
-
-class OutgoingMessageDecimalEncoder(BaseEncoder):
-    """Encoder to limit the precision of decimal values sent to charge points.
-
-    This encoder doesn't restricts the precision of float values received from the charge point, as we *must* keep the
-    full resolution, but limits it to 6 places when sending a value, as required by OCPP 2.0 spec (section 2.1.3).
-    """
-
-    def from_json(self, json_value):
-        return json_value
-
-    def to_json(self, value):
-        try:
-            float_value = float(value)
-        except ValueError:
-            raise errors.TypeConstraintViolationError(f"Input '{value}' cannot be cast to float", value=value)
-
-        six_places = decimal.Decimal('1.000000')
-        try:
-            truncated_value = float(decimal.Decimal(float_value).quantize(six_places, rounding=decimal.ROUND_DOWN))
-        except decimal.DecimalException as exc:
-            raise errors.TypeConstraintViolationError(
-                f"Input '{value}' could not be truncated to six decimal places",
-                value=value,
-            ) from exc
-
-        return truncated_value

--- a/ocpp_codec/validators.py
+++ b/ocpp_codec/validators.py
@@ -31,15 +31,6 @@ from ocpp_codec import errors
 ###########
 # Utilities
 
-def compound_validator(*validators: typing.Callable[[typing.Any], typing.Any]):
-    """Run several validators on the same input data."""
-    def _validator(value):
-        for v in validators:
-            value = v(value)
-        return value
-    return _validator
-
-
 def build_simple_validator(func: typing.Callable, *args, **kwargs) -> typing.Callable[[typing.Any], typing.Any]:
     """Build a ready-to-use simple validator out of a function.
 
@@ -110,9 +101,6 @@ def is_not_zero(value: typing.Union[int, float]) -> typing.Union[int, float]:
     if value == 0:
         raise errors.PropertyConstraintViolationError("Input is zero")
     return value
-
-
-is_strictly_positive = compound_validator(is_positive, is_not_zero)
 
 
 _IDENTIFIER_REGEXP = re.compile('[a-zA-Z0-9' + re.escape('*_=:+|@.-') + ']*')

--- a/ocpp_codec/validators.py
+++ b/ocpp_codec/validators.py
@@ -41,11 +41,6 @@ def build_simple_validator(func: typing.Callable, *args, **kwargs) -> typing.Cal
 ############
 # Validators
 
-def noop(value: typing.Any) -> typing.Any:
-    """A no-op validator, used as a default validator when none is specified."""
-    return value
-
-
 def max_length(length: int, value: typing.Any) -> typing.Any:
     """Validates that an input doesn't exceed a given length."""
     actual_length = len(value)

--- a/tests/messages.py
+++ b/tests/messages.py
@@ -26,7 +26,7 @@ class ComplexAction:
     @dataclass
     class req:
         complexValue: types.ComplexType
-        listValue: typing.List[types.ListElementType] = field(metadata={'validator': validators.max_length_4})
+        listValue: typing.List[types.ListElementType] = field(metadata={'validators': validators.max_length_4})
 
         optionalValue: str = None
 
@@ -34,7 +34,7 @@ class ComplexAction:
     class conf:
         optionalListValue: typing.List[str] = None
         optionalComplexListValue: typing.List[types.ComplexType] = field(
-            default=None, metadata={'validator': validators.max_length_4},
+            default=None, metadata={'validators': validators.max_length_4},
         )
 
 

--- a/tests/messages.py
+++ b/tests/messages.py
@@ -26,7 +26,7 @@ class ComplexAction:
     @dataclass
     class req:
         complexValue: types.ComplexType
-        listValue: typing.List[types.ListElementType] = field(metadata={'validators': validators.max_length_4})
+        listValue: typing.List[types.ListElementType] = field(metadata={'validators': [validators.max_length_4]})
 
         optionalValue: str = None
 
@@ -34,7 +34,7 @@ class ComplexAction:
     class conf:
         optionalListValue: typing.List[str] = None
         optionalComplexListValue: typing.List[types.ComplexType] = field(
-            default=None, metadata={'validators': validators.max_length_4},
+            default=None, metadata={'validators': [validators.max_length_4]},
         )
 
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,0 +1,75 @@
+# Copyright (c) Polyconseil SAS. All rights reserved.
+import datetime
+import enum
+
+import pytest
+import pytz
+
+from ocpp_codec import encoders
+from ocpp_codec import errors
+
+
+def test_datetime_encoder():
+    encoder = encoders.DateTimeEncoder()
+
+    with pytest.raises(errors.PropertyConstraintViolationError):
+        encoder.from_json('well thats not a date')
+    # Date must be UTC
+    with pytest.raises(errors.PropertyConstraintViolationError):
+        encoder.from_json('2019-03-21T12:00:00+01:00')
+    dt = datetime.datetime(year=2019, month=3, day=21, hour=12, tzinfo=pytz.UTC)
+    # Naive dates are considered UTC
+    assert encoder.from_json('2019-03-21T12:00:00') == dt
+    # Proper UTC formatting
+    assert encoder.from_json('2019-03-21T12:00:00+00:00') == dt
+    assert encoder.from_json('2019-03-21T12:00:00Z') == dt
+
+    with pytest.raises(errors.TypeConstraintViolationError):
+        encoder.to_json('well thats not a date')
+    # Naive datetime
+    with pytest.raises(errors.PropertyConstraintViolationError):
+        encoder.to_json(datetime.datetime(year=2019, month=3, day=21, hour=12))
+    # Wrong tzinfo
+    with pytest.raises(errors.PropertyConstraintViolationError):
+        encoder.to_json(
+            datetime.datetime(year=2019, month=3, day=21, hour=12, tzinfo=pytz.timezone('Europe/Paris'))
+        )
+    assert (
+        encoder.to_json(datetime.datetime(year=2019, month=3, day=21, hour=12, tzinfo=pytz.UTC))
+        == '2019-03-21T12:00:00+00:00'
+    )
+
+
+def test_enum_encoder():
+    class TestEnum(enum.Enum):
+        A = 1
+        B = 'b'
+
+    encoder = encoders.EnumEncoder(TestEnum)
+
+    with pytest.raises(errors.PropertyConstraintViolationError):
+        encoder.from_json(123)
+    assert encoder.from_json(1) == TestEnum.A
+    assert encoder.from_json('b') == TestEnum.B
+
+    with pytest.raises(errors.TypeConstraintViolationError):
+        encoder.to_json('well thats not an enum')
+    assert encoder.to_json(TestEnum.A) == 1
+    assert encoder.to_json(TestEnum.B) == 'b'
+
+
+def test_outgoing_message_decimal_encoder():
+    encoder = encoders.OutgoingMessageDecimalEncoder()
+
+    assert encoder.from_json(1.123456789) == 1.123456789
+
+    with pytest.raises(errors.TypeConstraintViolationError):
+        encoder.to_json('well thats not a float')
+    with pytest.raises(errors.TypeConstraintViolationError):
+        # Too big
+        assert encoder.to_json('112345599999999994030193027055616.1234567890')
+
+    assert encoder.to_json('1.12') == 1.12
+    assert encoder.to_json('1.123456789') == 1.123456
+    assert encoder.to_json('0.00001') == 1e-05
+    assert encoder.to_json('1e-05') == 1e-05

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -29,6 +29,15 @@ def test_parse_field():
     with pytest.raises(errors.TypeConstraintViolationError):
         serializer.parse_field(validated_field, 123)
 
+    # Multiple validators are applied in sequence
+    positive_float_field = fields(types.SeveralValidatorsType)[0]
+    with pytest.raises(errors.PropertyConstraintViolationError):
+        serializer.parse_field(positive_float_field, -2.1)
+    with pytest.raises(errors.PropertyConstraintViolationError):
+        serializer.parse_field(positive_float_field, 2.12)
+    validated_data = serializer.parse_field(positive_float_field, 2.1)
+    assert validated_data == 2.1
+
     # Check that a field with an encoder converts the type accordingly
     datetime_field = fields(types.DateTimeType)[0]
     dt = serializer.parse_field(datetime_field, '2019-01-30T12:30:00Z')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -76,12 +76,6 @@ def test_is_positive_validators():
     assert validators.is_not_zero(-1) == -1
     assert validators.is_not_zero(1) == 1
 
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        validators.is_strictly_positive(-1)
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        validators.is_strictly_positive(0)
-    assert validators.is_strictly_positive(1) == 1
-
 
 def test_is_identifier():
     with pytest.raises(errors.PropertyConstraintViolationError):
@@ -153,12 +147,3 @@ def test_outgoing_message_decimal_encoder():
     assert encoder.to_json('1.123456789') == 1.123456
     assert encoder.to_json('0.00001') == 1e-05
     assert encoder.to_json('1e-05') == 1e-05
-
-
-def test_compound_validator():
-    validator = validators.compound_validator(validators.is_positive, validators.decimal_precision_1)
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        validator(-2.1)
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        validator(2.12)
-    assert validator(2.1) == 2.1

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,9 +1,5 @@
 # Copyright (c) Polyconseil SAS. All rights reserved.
-import datetime
-import enum
-
 import pytest
-import pytz
 
 from ocpp_codec import errors
 from ocpp_codec import validators
@@ -81,69 +77,3 @@ def test_is_identifier():
     with pytest.raises(errors.PropertyConstraintViolationError):
         validators.is_identifier('!#$%^&()')
     assert validators.is_identifier('Id06-@') == 'Id06-@'
-
-
-def test_datetime_encoder():
-    encoder = validators.DateTimeEncoder()
-
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        encoder.from_json('well thats not a date')
-    # Date must be UTC
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        encoder.from_json('2019-03-21T12:00:00+01:00')
-    dt = datetime.datetime(year=2019, month=3, day=21, hour=12, tzinfo=pytz.UTC)
-    # Naive dates are considered UTC
-    assert encoder.from_json('2019-03-21T12:00:00') == dt
-    # Proper UTC formatting
-    assert encoder.from_json('2019-03-21T12:00:00+00:00') == dt
-    assert encoder.from_json('2019-03-21T12:00:00Z') == dt
-
-    with pytest.raises(errors.TypeConstraintViolationError):
-        encoder.to_json('well thats not a date')
-    # Naive datetime
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        encoder.to_json(datetime.datetime(year=2019, month=3, day=21, hour=12))
-    # Wrong tzinfo
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        encoder.to_json(
-            datetime.datetime(year=2019, month=3, day=21, hour=12, tzinfo=pytz.timezone('Europe/Paris'))
-        )
-    assert (
-        encoder.to_json(datetime.datetime(year=2019, month=3, day=21, hour=12, tzinfo=pytz.UTC))
-        == '2019-03-21T12:00:00+00:00'
-    )
-
-
-def test_enum_encoder():
-    class TestEnum(enum.Enum):
-        A = 1
-        B = 'b'
-
-    encoder = validators.EnumEncoder(TestEnum)
-
-    with pytest.raises(errors.PropertyConstraintViolationError):
-        encoder.from_json(123)
-    assert encoder.from_json(1) == TestEnum.A
-    assert encoder.from_json('b') == TestEnum.B
-
-    with pytest.raises(errors.TypeConstraintViolationError):
-        encoder.to_json('well thats not an enum')
-    assert encoder.to_json(TestEnum.A) == 1
-    assert encoder.to_json(TestEnum.B) == 'b'
-
-
-def test_outgoing_message_decimal_encoder():
-    encoder = validators.OutgoingMessageDecimalEncoder()
-
-    assert encoder.from_json(1.123456789) == 1.123456789
-
-    with pytest.raises(errors.TypeConstraintViolationError):
-        encoder.to_json('well thats not a float')
-    with pytest.raises(errors.TypeConstraintViolationError):
-        # Too big
-        assert encoder.to_json('112345599999999994030193027055616.1234567890')
-
-    assert encoder.to_json('1.12') == 1.12
-    assert encoder.to_json('1.123456789') == 1.123456
-    assert encoder.to_json('0.00001') == 1e-05
-    assert encoder.to_json('1e-05') == 1e-05

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -14,10 +14,6 @@ def test_build_simple_validator():
     assert validator('test') == ('arg', 'test')
 
 
-def test_noop():
-    assert validators.noop('value') == 'value'
-
-
 def test_max_length_validators():
     with pytest.raises(errors.PropertyConstraintViolationError):
         validators.max_length(10, 'a' * 11)

--- a/tests/types.py
+++ b/tests/types.py
@@ -18,7 +18,7 @@ class FooBarEnum(utils.AutoNameEnum):
 
 @dataclass
 class ValidatedType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.max_length_20})
+    value: str = field(metadata={'validators': [validators.max_length_20]})
 
 
 @dataclass

--- a/tests/types.py
+++ b/tests/types.py
@@ -5,6 +5,7 @@ from dataclasses import field
 import enum
 import typing
 
+from ocpp_codec import encoders
 from ocpp_codec import types
 from ocpp_codec import utils
 from ocpp_codec import validators
@@ -27,12 +28,12 @@ class SeveralValidatorsType(types.SimpleType):
 
 @dataclass
 class DateTimeType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.DateTimeEncoder()})
+    value: str = field(metadata={'encoder': encoders.DateTimeEncoder()})
 
 
 @dataclass
 class EnumType(types.SimpleType):
-    value: str = field(metadata={'validators': validators.EnumEncoder(FooBarEnum)})
+    value: str = field(metadata={'encoder': encoders.EnumEncoder(FooBarEnum)})
 
 
 @dataclass

--- a/tests/types.py
+++ b/tests/types.py
@@ -17,17 +17,17 @@ class FooBarEnum(utils.AutoNameEnum):
 
 @dataclass
 class ValidatedType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.max_length_20})
+    value: str = field(metadata={'validators': validators.max_length_20})
 
 
 @dataclass
 class DateTimeType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.DateTimeEncoder()})
+    value: str = field(metadata={'validators': validators.DateTimeEncoder()})
 
 
 @dataclass
 class EnumType(types.SimpleType):
-    value: str = field(metadata={'validator': validators.EnumEncoder(FooBarEnum)})
+    value: str = field(metadata={'validators': validators.EnumEncoder(FooBarEnum)})
 
 
 @dataclass

--- a/tests/types.py
+++ b/tests/types.py
@@ -21,6 +21,11 @@ class ValidatedType(types.SimpleType):
 
 
 @dataclass
+class SeveralValidatorsType(types.SimpleType):
+    value: float = field(metadata={'validators': [validators.is_positive, validators.decimal_precision_1]})
+
+
+@dataclass
 class DateTimeType(types.SimpleType):
     value: str = field(metadata={'validators': validators.DateTimeEncoder()})
 


### PR DESCRIPTION
Taking feedback into account:

- drop `compound_validator` in favor of defining a list of validators to run;
- add a dedicated `'encoder'` field metadata attribute instead of mixing encoders with validators, as they're not the same.